### PR TITLE
Fixing remove_wanted_p function

### DIFF
--- a/loop-shortcode.php
+++ b/loop-shortcode.php
@@ -72,7 +72,7 @@ class CTLT_Loop_Shortcode {
 		
 		$content = trim($content);
 		// remove the opening <p> tag
-		if( strpos($content, '<p>') === 0  )
+		if( strcasecmp(substr($content, 0, 3), '<p>') === 0  )
 			$content = substr($content, 3);
 		// remove the closing </p> tag
 		if( strcasecmp(substr($content, -4), '</p>') === 0 )


### PR DESCRIPTION
The remove_wanted_p function isn't working properly; it incorrectly strips content other than paragraph tags, partially because it reversed the beginning and ending and partially because it was using double equals for comparison on the return value of strpos instead of triple equals.
